### PR TITLE
Update cd.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Tag Build
         shell: pwsh
-        run: ./build/scripts/tagbuild.ps1
+        run: ./.github/scripts/tagbuild.ps1
 
   batch0:
     needs: pre


### PR DESCRIPTION
This pull request includes a small change to the `cd.yml` file in the `.github/workflows` directory. The change updates the path to the `tagbuild.ps1` script to reflect its new location.

* [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L40-R40): Updated the script path from `./build/scripts/tagbuild.ps1` to `./.github/scripts/tagbuild.ps1`.