### PR TITLE
Adding Async versions of the overridden methods

### DIFF
--- a/src/E13.Common.Data.Db/Interceptors/CreatableInterceptor.cs
+++ b/src/E13.Common.Data.Db/Interceptors/CreatableInterceptor.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace E13.Common.Data.Db.Interceptors
@@ -12,19 +13,42 @@ namespace E13.Common.Data.Db.Interceptors
     public sealed class CreatableInterceptor : SaveChangesInterceptor
     {
         public override InterceptionResult<int> SavingChanges(
-            DbContextEventData data,
+            DbContextEventData eventData,
             InterceptionResult<int> result)
         {
-            var auditContext = data.Context as IAuditContext ?? throw new Exception("Audit context is not set.");
+            var auditContext = eventData.Context as IAuditContext ?? throw new Exception("Audit context is not set.");
 
-            foreach (var entry in data.Context!.ChangeTracker.Entries<ICreatable>()
+            HandleEventData(eventData, auditContext);
+
+            return base.SavingChanges(eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+            DbContextEventData eventData, 
+            InterceptionResult<int> result, 
+            CancellationToken cancellationToken = default)
+        {
+            var auditContext = eventData.Context as IAuditContext ?? throw new Exception("Audit context is not set.");
+
+            HandleEventData(eventData, auditContext);
+
+            return base.SavingChangesAsync(eventData, result, cancellationToken);
+        }
+
+        /// <summary>
+        /// Handles the event data for the creatable entities.
+        /// </summary>
+        /// <param name="eventData"></param>
+        /// <param name="auditContext"></param>
+        private static void HandleEventData(DbContextEventData eventData, IAuditContext auditContext)
+        {
+            foreach (var entry in eventData.Context!.ChangeTracker.Entries<ICreatable>()
                          .Where(e => e.State == EntityState.Added))
             {
                 entry.Entity.Created = DateTime.UtcNow;
                 entry.Entity.CreatedBy = auditContext.AuditUser;
                 entry.Entity.CreatedSource = auditContext.Source;
             }
-            return base.SavingChanges(data, result);
         }
     }
 }

--- a/src/E13.Common.Data.Db/Interceptors/ModifiableInterceptor.cs
+++ b/src/E13.Common.Data.Db/Interceptors/ModifiableInterceptor.cs
@@ -6,25 +6,50 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Threading;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace E13.Common.Data.Db.Interceptors
 {
     public sealed class ModifiableInterceptor : SaveChangesInterceptor
     {
         public override InterceptionResult<int> SavingChanges(
-            DbContextEventData data,
+            DbContextEventData eventData,
             InterceptionResult<int> result)
         {
-            var auditContext = data.Context as IAuditContext ?? throw new Exception("Audit context is not set.");
+            var auditContext = eventData.Context as IAuditContext ?? throw new Exception("Audit context is not set.");
 
-            foreach (var entry in data.Context!.ChangeTracker.Entries<IModifiable>()
+            HandleEventData(eventData, auditContext);
+
+            return base.SavingChanges(eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+            DbContextEventData eventData,
+            InterceptionResult<int> result,
+            CancellationToken cancellationToken = default)
+        {
+            var auditContext = eventData.Context as IAuditContext ?? throw new Exception("Audit context is not set.");
+
+            HandleEventData(eventData, auditContext);
+
+            return base.SavingChangesAsync(eventData, result, cancellationToken);
+        }
+
+        /// <summary>
+        /// Handles the event data for the creatable entities.
+        /// </summary>
+        /// <param name="eventData"></param>
+        /// <param name="auditContext"></param>
+        private static void HandleEventData(DbContextEventData eventData, IAuditContext auditContext)
+        {
+            foreach (var entry in eventData.Context!.ChangeTracker.Entries<IModifiable>()
                          .Where(e => e.State is EntityState.Added or EntityState.Modified))
             {
                 entry.Entity.Modified = DateTime.UtcNow;
                 entry.Entity.ModifiedBy = auditContext.AuditUser;
                 entry.Entity.ModifiedSource = auditContext.Source;
             }
-            return base.SavingChanges(data, result);
         }
     }
 }


### PR DESCRIPTION
This pull request refactors the `SavingChanges` methods in three database interceptors (`CreatableInterceptor`, `ModifiableInterceptor`, and `SoftDeleteInterceptor`) to improve code reuse and add asynchronous support. The changes include introducing a shared `HandleEventData` method in each class and implementing the `SavingChangesAsync` method for better handling of asynchronous database operations.

### Refactoring for code reuse and consistency:
* Extracted shared logic into a new `HandleEventData` method in `CreatableInterceptor`, `ModifiableInterceptor`, and `SoftDeleteInterceptor` to handle entity state changes consistently. This method processes the `ChangeTracker` entries based on the specific entity types (`ICreatable`, `IModifiable`, `IDeletable`) and updates their audit fields. [[1]](diffhunk://#diff-67e9158878e970329ab9b76ea0b84acac8c1954dcc63cb5065d768e80f8c8a02R8-L27) [[2]](diffhunk://#diff-9ad0c78a5e07762cc57a1e834a5d7079ed968dd51397dd933777ccb5b44aa524R9-L27) [[3]](diffhunk://#diff-42b192b1c9fd2f69a43300b16cebbbfca1edb094c6c67fa44e7dda51cb70d105R9-R46)

### Asynchronous support:
* Added `SavingChangesAsync` methods to all three interceptors (`CreatableInterceptor`, `ModifiableInterceptor`, `SoftDeleteInterceptor`) to handle asynchronous database save operations, leveraging the `CancellationToken` parameter for cancellation support. [[1]](diffhunk://#diff-67e9158878e970329ab9b76ea0b84acac8c1954dcc63cb5065d768e80f8c8a02R8-L27) [[2]](diffhunk://#diff-9ad0c78a5e07762cc57a1e834a5d7079ed968dd51397dd933777ccb5b44aa524R9-L27) [[3]](diffhunk://#diff-42b192b1c9fd2f69a43300b16cebbbfca1edb094c6c67fa44e7dda51cb70d105R9-R46)

### Minor improvements:
* Renamed the `data` parameter to `eventData` in `SavingChanges` methods for better clarity and alignment with naming conventions. [[1]](diffhunk://#diff-67e9158878e970329ab9b76ea0b84acac8c1954dcc63cb5065d768e80f8c8a02R8-L27) [[2]](diffhunk://#diff-9ad0c78a5e07762cc57a1e834a5d7079ed968dd51397dd933777ccb5b44aa524R9-L27) [[3]](diffhunk://#diff-42b192b1c9fd2f69a43300b16cebbbfca1edb094c6c67fa44e7dda51cb70d105R9-R46)