### PR TITLE
updated metadata for generated nuget package

### DIFF
--- a/src/E13.Common.Data/DataException.cs
+++ b/src/E13.Common.Data/DataException.cs
@@ -1,4 +1,6 @@
-﻿namespace E13.Common.Data
+﻿using System;
+
+namespace E13.Common.Data
 {
     public class DataException : Exception
     {

--- a/src/E13.Common.Data/E13.Common.Data.csproj
+++ b/src/E13.Common.Data/E13.Common.Data.csproj
@@ -1,9 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Company>E13 Tech</Company>
+    <Authors>JJ Bussert</Authors>
+    <PackageProjectUrl>https://www.e13.tech</PackageProjectUrl>
+    <ApplicationIcon>..\..\design\E13.ico</ApplicationIcon>
+    <PackageIcon>E13.png</PackageIcon>
+    <RepositoryUrl>https://github.com/e13tech/common</RepositoryUrl>
+    <Description>Common package containing components common for any Data layer</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <ProjectGuid>{3A53E164-213D-4C16-A18E-DB73FABC354D}</ProjectGuid>
+
     <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>true</IsPackable>
     <Nullable>enable</Nullable>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\design\E13.png" Pack="true" PackagePath="\" />
+    <None Include="docs\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request updates the `E13.Common.Data` project file to enhance its metadata and packaging configuration, aligning it with modern .NET standards and best practices. The key changes include the addition of metadata for NuGet packaging, updates to project settings, and inclusion of resources for packaging.

### Metadata and packaging enhancements:
* Added NuGet metadata fields such as `Company`, `Authors`, `PackageProjectUrl`, `Description`, `PackageLicenseExpression`, `RepositoryUrl`, and `PackageReadmeFile` to improve the package's documentation and discoverability.
* Included `ApplicationIcon` and `PackageIcon` references, pointing to project-specific design assets.
* Added an `ItemGroup` to include the icon and README file in the NuGet package.

### Project settings updates:
* Enabled `IsPackable`, `PublishRepositoryUrl`, and `EmbedUntrackedSources` to support better packaging and source-linking capabilities.
* Allowed `.pdb` files in the package build output folder for debugging support.