### PR TITLE
Convert IOwnable to have a type that will allow typed ownership

### DIFF
--- a/src/E13.Common.Domain/IOwnable.cs
+++ b/src/E13.Common.Domain/IOwnable.cs
@@ -4,9 +4,9 @@ using System.Text;
 
 namespace E13.Common.Domain
 {
-    public interface IOwnable : IEntity
+    public interface IOwnable<T> : IEntity
     {
-        string OwnedBy { get; set; }
+        T OwnedBy { get; set; }
         string OwnedSource { get; set; }
         DateTime Owned { get; set; }
     }

--- a/test/E13.Common.Data.Db.Tests/Sample/TestOwnable.cs
+++ b/test/E13.Common.Data.Db.Tests/Sample/TestOwnable.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace E13.Common.Data.Db.Tests.Sample
 {
-    public class TestOwnable : IOwnable
+    public class TestOwnable : IOwnable<string>
     {
         public Guid Id { get; set; }
         public string OwnedBy { get; set; } = "OwnedBy";


### PR DESCRIPTION
This pull request introduces a generic type parameter to the `IOwnable` interface, allowing greater flexibility in specifying the type of the `OwnedBy` property. The changes also update the `TestOwnable` class to implement the modified interface with a `string` type for the `OwnedBy` property.

### Changes to the `IOwnable` interface:

* Modified the `IOwnable` interface to include a generic type parameter `<T>`, replacing the `string` type for the `OwnedBy` property with the generic type `T`. (`src/E13.Common.Domain/IOwnable.cs`, [src/E13.Common.Domain/IOwnable.csL7-R9](diffhunk://#diff-1fd14297cdaef9403383297277086f4ee3f4864682463c8ed9988b9e8fcd240fL7-R9))

### Updates to the `TestOwnable` class:

* Updated the `TestOwnable` class to implement the new `IOwnable<T>` interface, specifying `string` as the type for the `OwnedBy` property. (`test/E13.Common.Data.Db.Tests/Sample/TestOwnable.cs`, [test/E13.Common.Data.Db.Tests/Sample/TestOwnable.csL10-R10](diffhunk://#diff-c937a91fed222ee7a320f879f5505eaf6be23cdef4088a8daf364b767870930aL10-R10))