### PR TITLE
Refactor DbContext and related interfaces to be generic

### DIFF
--- a/src/E13.Common.Data.Db/IAuditContext.cs
+++ b/src/E13.Common.Data.Db/IAuditContext.cs
@@ -6,9 +6,9 @@ using System.Threading.Tasks;
 
 namespace E13.Common.Data.Db
 {
-    public interface IAuditContext
+    public interface IAuditContext<T>
     {
-        string? AuditUser { get; }
+        T AuditUser { get; }
         string? Source { get; }
     }
 }

--- a/src/E13.Common.Data.Db/Interceptors/CreatableInterceptor.cs
+++ b/src/E13.Common.Data.Db/Interceptors/CreatableInterceptor.cs
@@ -10,13 +10,13 @@ using System.Threading.Tasks;
 
 namespace E13.Common.Data.Db.Interceptors
 {
-    public sealed class CreatableInterceptor : SaveChangesInterceptor
+    public sealed class CreatableInterceptor<T> : SaveChangesInterceptor
     {
         public override InterceptionResult<int> SavingChanges(
             DbContextEventData eventData,
             InterceptionResult<int> result)
         {
-            var auditContext = eventData.Context as IAuditContext ?? throw new Exception("Audit context is not set.");
+            var auditContext = eventData.Context as IAuditContext<T> ?? throw new Exception("Audit context is not set.");
 
             HandleEventData(eventData, auditContext);
 
@@ -28,7 +28,7 @@ namespace E13.Common.Data.Db.Interceptors
             InterceptionResult<int> result, 
             CancellationToken cancellationToken = default)
         {
-            var auditContext = eventData.Context as IAuditContext ?? throw new Exception("Audit context is not set.");
+            var auditContext = eventData.Context as IAuditContext<T> ?? throw new Exception("Audit context is not set.");
 
             HandleEventData(eventData, auditContext);
 
@@ -40,9 +40,9 @@ namespace E13.Common.Data.Db.Interceptors
         /// </summary>
         /// <param name="eventData"></param>
         /// <param name="auditContext"></param>
-        private static void HandleEventData(DbContextEventData eventData, IAuditContext auditContext)
+        private static void HandleEventData(DbContextEventData eventData, IAuditContext<T> auditContext)
         {
-            foreach (var entry in eventData.Context!.ChangeTracker.Entries<ICreatable>()
+            foreach (var entry in eventData.Context!.ChangeTracker.Entries<ICreatable<T>>()
                          .Where(e => e.State == EntityState.Added))
             {
                 entry.Entity.Created = DateTime.UtcNow;

--- a/src/E13.Common.Data.Db/Interceptors/ModifiableInterceptor.cs
+++ b/src/E13.Common.Data.Db/Interceptors/ModifiableInterceptor.cs
@@ -11,13 +11,13 @@ using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace E13.Common.Data.Db.Interceptors
 {
-    public sealed class ModifiableInterceptor : SaveChangesInterceptor
+    public sealed class ModifiableInterceptor<T> : SaveChangesInterceptor
     {
         public override InterceptionResult<int> SavingChanges(
             DbContextEventData eventData,
             InterceptionResult<int> result)
         {
-            var auditContext = eventData.Context as IAuditContext ?? throw new Exception("Audit context is not set.");
+            var auditContext = eventData.Context as IAuditContext<T> ?? throw new Exception("Audit context is not set.");
 
             HandleEventData(eventData, auditContext);
 
@@ -29,7 +29,7 @@ namespace E13.Common.Data.Db.Interceptors
             InterceptionResult<int> result,
             CancellationToken cancellationToken = default)
         {
-            var auditContext = eventData.Context as IAuditContext ?? throw new Exception("Audit context is not set.");
+            var auditContext = eventData.Context as IAuditContext<T> ?? throw new Exception("Audit context is not set.");
 
             HandleEventData(eventData, auditContext);
 
@@ -41,9 +41,9 @@ namespace E13.Common.Data.Db.Interceptors
         /// </summary>
         /// <param name="eventData"></param>
         /// <param name="auditContext"></param>
-        private static void HandleEventData(DbContextEventData eventData, IAuditContext auditContext)
+        private static void HandleEventData(DbContextEventData eventData, IAuditContext<T> auditContext)
         {
-            foreach (var entry in eventData.Context!.ChangeTracker.Entries<IModifiable>()
+            foreach (var entry in eventData.Context!.ChangeTracker.Entries<IModifiable<T>>()
                          .Where(e => e.State is EntityState.Added or EntityState.Modified))
             {
                 entry.Entity.Modified = DateTime.UtcNow;

--- a/src/E13.Common.Data.Db/Interceptors/SoftDeleteInterceptor.cs
+++ b/src/E13.Common.Data.Db/Interceptors/SoftDeleteInterceptor.cs
@@ -7,17 +7,16 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Threading;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace E13.Common.Data.Db.Interceptors
 {
-    public sealed class SoftDeleteInterceptor : SaveChangesInterceptor
+    public sealed class SoftDeleteInterceptor<T> : SaveChangesInterceptor
     {
         public override InterceptionResult<int> SavingChanges(
             DbContextEventData eventData,
             InterceptionResult<int> result)
         {
-            var auditContext = eventData.Context as IAuditContext ?? throw new Exception("Audit context is not set.");
+            var auditContext = eventData.Context as IAuditContext<T> ?? throw new Exception("Audit context is not set.");
 
             HandleEventData(eventData, auditContext);
 
@@ -29,7 +28,7 @@ namespace E13.Common.Data.Db.Interceptors
             InterceptionResult<int> result,
             CancellationToken cancellationToken = default)
         {
-            var auditContext = eventData.Context as IAuditContext ?? throw new Exception("Audit context is not set.");
+            var auditContext = eventData.Context as IAuditContext<T> ?? throw new Exception("Audit context is not set.");
 
             HandleEventData(eventData, auditContext);
 
@@ -41,9 +40,9 @@ namespace E13.Common.Data.Db.Interceptors
         /// </summary>
         /// <param name="eventData"></param>
         /// <param name="auditContext"></param>
-        private static void HandleEventData(DbContextEventData eventData, IAuditContext auditContext)
+        private static void HandleEventData(DbContextEventData eventData, IAuditContext<T> auditContext)
         {
-            foreach (var entry in eventData.Context!.ChangeTracker.Entries<IDeletable>())
+            foreach (var entry in eventData.Context!.ChangeTracker.Entries<IDeletable<T>>())
             {
                 if (entry.State == EntityState.Deleted)
                 {
@@ -59,7 +58,7 @@ namespace E13.Common.Data.Db.Interceptors
                 {
                     // “undelete” scenario
                     entry.Entity.Deleted = null;
-                    entry.Entity.DeletedBy = null;
+                    entry.Entity.DeletedBy = default(T);
                     entry.Entity.DeletedSource = null;
                 }
             }

--- a/src/E13.Common.Domain/ICreatable.cs
+++ b/src/E13.Common.Domain/ICreatable.cs
@@ -6,9 +6,9 @@ using System.Threading.Tasks;
 
 namespace E13.Common.Domain
 {
-    public interface ICreatable : IEntity
+    public interface ICreatable<T> : IEntity
     {
-        string? CreatedBy { get; set; }
+        T? CreatedBy { get; set; }
         string? CreatedSource { get; set; }
         DateTime? Created { get; set; }
     }

--- a/src/E13.Common.Domain/IDeletable.cs
+++ b/src/E13.Common.Domain/IDeletable.cs
@@ -4,9 +4,9 @@ using System.Text;
 
 namespace E13.Common.Domain
 {
-    public interface IDeletable : IEntity
+    public interface IDeletable<T> : IEntity
     {
-        string? DeletedBy { get; set; }
+        T DeletedBy { get; set; }
         string? DeletedSource { get; set; }
         DateTime? Deleted { get; set; }
 

--- a/src/E13.Common.Domain/IEffectable.cs
+++ b/src/E13.Common.Domain/IEffectable.cs
@@ -4,9 +4,9 @@ using System.Text;
 
 namespace E13.Common.Domain
 {
-    public interface IEffectable : IEntity
+    public interface IEffectable<T> : IEntity
     {
-        string? EffectiveBy { get; set; }
+        T EffectiveBy { get; set; }
         string? EffectiveSource { get; set; }
         DateTime? Effective { get; set; }
     }

--- a/src/E13.Common.Domain/IExpirable.cs
+++ b/src/E13.Common.Domain/IExpirable.cs
@@ -4,10 +4,10 @@ using System.Text;
 
 namespace E13.Common.Domain
 {
-    public interface IExpirable : IEntity
+    public interface IExpirable<T> : IEntity
     {
-        string ExpirationBy { get; set; }
-        string ExpirationSource { get; set; }
-        DateTime Expiration { get; set; }
+        T ExpirationBy { get; set; }
+        string? ExpirationSource { get; set; }
+        DateTime? Expiration { get; set; }
     }
 }

--- a/src/E13.Common.Domain/IModifiable.cs
+++ b/src/E13.Common.Domain/IModifiable.cs
@@ -6,9 +6,9 @@ using System.Threading.Tasks;
 
 namespace E13.Common.Domain
 {
-    public interface IModifiable : IEntity
+    public interface IModifiable<T> : IEntity
     {
-        string? ModifiedBy { get; set; }
+        T ModifiedBy { get; set; }
         string? ModifiedSource { get; set; }
         DateTime? Modified { get; set; }
     }

--- a/src/E13.Common.Domain/IOwnable.cs
+++ b/src/E13.Common.Domain/IOwnable.cs
@@ -7,7 +7,7 @@ namespace E13.Common.Domain
     public interface IOwnable<T> : IEntity
     {
         T OwnedBy { get; set; }
-        string OwnedSource { get; set; }
-        DateTime Owned { get; set; }
+        string? OwnedSource { get; set; }
+        DateTime? Owned { get; set; }
     }
 }

--- a/test/E13.Common.Data.Db.Tests/BaseDbContext_ICreatableTests.cs
+++ b/test/E13.Common.Data.Db.Tests/BaseDbContext_ICreatableTests.cs
@@ -17,17 +17,17 @@ namespace E13.Common.Data.Db.Tests
         public void Setup()
         {
             var services = new ServiceCollection();
-            services.AddScoped<CreatableInterceptor>();
-            services.AddScoped<ModifiableInterceptor>();
-            services.AddScoped<SoftDeleteInterceptor>();
-            services.AddDbContext<IAuditContext, TestDbContext>((sp, o) =>
+            services.AddScoped<CreatableInterceptor<string>>();
+            services.AddScoped<ModifiableInterceptor<string>>();
+            services.AddScoped<SoftDeleteInterceptor<string>>();
+            services.AddDbContext<IAuditContext<string>, TestDbContext>((sp, o) =>
             {
                 o.UseInMemoryDatabase($"{Guid.NewGuid()}");
                 o.EnableSensitiveDataLogging();
                 o.AddInterceptors(
-                    sp.GetRequiredService<CreatableInterceptor>(),
-                    sp.GetRequiredService<ModifiableInterceptor>(),
-                    sp.GetRequiredService<SoftDeleteInterceptor>());
+                    sp.GetRequiredService<CreatableInterceptor<string>>(),
+                    sp.GetRequiredService<ModifiableInterceptor<string>>(),
+                    sp.GetRequiredService<SoftDeleteInterceptor<string>>());
             });
 
             Context = services.BuildServiceProvider().GetService<TestDbContext>();
@@ -56,7 +56,7 @@ namespace E13.Common.Data.Db.Tests
 
             var arranged = Context.Creatables.First();
 
-            arranged.CreatedBy.Should().Be(BaseDbContext.UnknownUser);
+            arranged.CreatedBy.Should().Be(BaseDbContext<string>.UnknownUser);
         }
 
         [Test]
@@ -71,7 +71,7 @@ namespace E13.Common.Data.Db.Tests
 
             var arranged = Context.Creatables.First(e => e.Id == id);
 
-            arranged.CreatedBy.Should().Be(BaseDbContext.UnknownUser);
+            arranged.CreatedBy.Should().Be(BaseDbContext<string>.UnknownUser);
         }
 
         [Test]

--- a/test/E13.Common.Data.Db.Tests/BaseDbContext_IDeletableTests.cs
+++ b/test/E13.Common.Data.Db.Tests/BaseDbContext_IDeletableTests.cs
@@ -19,9 +19,9 @@ namespace E13.Common.Data.Db.Tests
             var services = new ServiceCollection();
             services.AddDbContext<TestDbContext>(o => {
                 o.UseInMemoryDatabase($"{Guid.NewGuid()}");
-                o.AddInterceptors(new CreatableInterceptor());
-                o.AddInterceptors(new ModifiableInterceptor());
-                o.AddInterceptors(new SoftDeleteInterceptor());
+                o.AddInterceptors(new CreatableInterceptor<string>());
+                o.AddInterceptors(new ModifiableInterceptor<string>());
+                o.AddInterceptors(new SoftDeleteInterceptor<string>());
             });
 
             Context = services.BuildServiceProvider().GetService<TestDbContext>();

--- a/test/E13.Common.Data.Db.Tests/BaseDbContext_IModifiableTests.cs
+++ b/test/E13.Common.Data.Db.Tests/BaseDbContext_IModifiableTests.cs
@@ -19,9 +19,9 @@ namespace E13.Common.Data.Db.Tests
             var services = new ServiceCollection();
             services.AddDbContext<TestDbContext>(o => {
                 o.UseInMemoryDatabase($"{Guid.NewGuid()}");
-                o.AddInterceptors(new CreatableInterceptor());
-                o.AddInterceptors(new ModifiableInterceptor());
-                o.AddInterceptors(new SoftDeleteInterceptor());
+                o.AddInterceptors(new CreatableInterceptor<string>());
+                o.AddInterceptors(new ModifiableInterceptor<string>());
+                o.AddInterceptors(new SoftDeleteInterceptor<string>());
             });
 
             Context = services.BuildServiceProvider().GetService<TestDbContext>();
@@ -79,7 +79,7 @@ namespace E13.Common.Data.Db.Tests
             Context.SaveChanges();
 
             var assert = Context.Modifiables.First();
-            assert.ModifiedBy.Should().Be(BaseDbContext.UnknownUser);
+            assert.ModifiedBy.Should().Be(BaseDbContext<string>.UnknownUser);
         }
 
         [Test]

--- a/test/E13.Common.Data.Db.Tests/Sample/TestCreatable.cs
+++ b/test/E13.Common.Data.Db.Tests/Sample/TestCreatable.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace E13.Common.Data.Db.Tests.Sample
 {
-    public class TestCreatable : ICreatable
+    public class TestCreatable : ICreatable<string>
     {
         public Guid Id { get; set; }
         public string Text { get; set; } = string.Empty;

--- a/test/E13.Common.Data.Db.Tests/Sample/TestDbContext.cs
+++ b/test/E13.Common.Data.Db.Tests/Sample/TestDbContext.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace E13.Common.Data.Db.Tests.Sample
 {
-    public class TestDbContext : BaseDbContext
+    public class TestDbContext : BaseDbContext<string>
     {
         public DbSet<TestCreatable> Creatables { get; set; }
         public DbSet<TestModifiable> Modifiables { get; set; }
@@ -29,6 +29,9 @@ namespace E13.Common.Data.Db.Tests.Sample
 
         public void AddTestData()
         {
+            AuditUser = UnknownUser;
+            Source = "E13.Common.Data.Db.Tests.Sample.TestDbContext.AddTestData";
+
             Creatables.Add(new TestCreatable
             {
                 Id = Guid.Empty
@@ -66,7 +69,7 @@ namespace E13.Common.Data.Db.Tests.Sample
                 DeletedSource = "PreviousSource"
             });
             // Because invalid data is being arranged the internal SaveChanges avoiding the TagEntries code must be used.
-            SaveChanges_NoTagEntries();
+            SaveChanges();
         }
     }
 }

--- a/test/E13.Common.Data.Db.Tests/Sample/TestDeletable.cs
+++ b/test/E13.Common.Data.Db.Tests/Sample/TestDeletable.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace E13.Common.Data.Db.Tests.Sample
 {
-    public class TestDeletable : IDeletable
+    public class TestDeletable : IDeletable<string>
     {
         public Guid Id { get; set; }
         public string? DeletedBy { get; set; }

--- a/test/E13.Common.Data.Db.Tests/Sample/TestEffectable.cs
+++ b/test/E13.Common.Data.Db.Tests/Sample/TestEffectable.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace E13.Common.Data.Db.Tests.Sample
 {
-    public class TestEffectable : IEffectable
+    public class TestEffectable : IEffectable<string>
     {
         public Guid Id { get; set; }
         public string? EffectiveBy { get; set; } = "EffectiveBy";

--- a/test/E13.Common.Data.Db.Tests/Sample/TestInvalidDeletable.cs
+++ b/test/E13.Common.Data.Db.Tests/Sample/TestInvalidDeletable.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace E13.Common.Data.Db.Tests.Sample
 {
-    public class TestInvalidDeletable : IDeletable
+    public class TestInvalidDeletable : IDeletable<string>
     {
         public Guid Id { get; set; }
         public string? DeletedBy { get; set; }

--- a/test/E13.Common.Data.Db.Tests/Sample/TestModifiable.cs
+++ b/test/E13.Common.Data.Db.Tests/Sample/TestModifiable.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace E13.Common.Data.Db.Tests.Sample
 {
-    public class TestModifiable : IModifiable
+    public class TestModifiable : IModifiable<string>
     {
         public Guid Id { get; set; }
         public string Text { get; set; } = string.Empty;

--- a/test/E13.Common.Data.Db.Tests/Sample/TestOwnable.cs
+++ b/test/E13.Common.Data.Db.Tests/Sample/TestOwnable.cs
@@ -10,8 +10,8 @@ namespace E13.Common.Data.Db.Tests.Sample
     public class TestOwnable : IOwnable<string>
     {
         public Guid Id { get; set; }
-        public string OwnedBy { get; set; } = "OwnedBy";
-        public string OwnedSource { get; set; } = "OwnedSource";
-        public DateTime Owned { get; set; }
+        public string? OwnedBy { get; set; } = "OwnedBy";
+        public string? OwnedSource { get; set; } = "OwnedSource";
+        public DateTime? Owned { get; set; }
     }
 }

--- a/test/E13.Common.Domain.Tests/IDeletableTests.cs
+++ b/test/E13.Common.Domain.Tests/IDeletableTests.cs
@@ -10,13 +10,13 @@ namespace E13.Common.Domain.Tests
         [Test]
         public void IsDeleted_DeletedNull_False()
         {
-            IDeletable arranged = new IDeletableSample { Deleted = null };
+            IDeletable<string> arranged = new IDeletableSample { Deleted = null };
 
             arranged.IsDeleted();
         }
     }
 
-    public class IDeletableSample : IDeletable
+    public class IDeletableSample : IDeletable<string>
     {
         public Guid Id { get; set; }
         public string? DeletedBy { get; set; }


### PR DESCRIPTION
This pull request introduces a generic type parameter `T` across multiple interfaces, classes, and interceptors in the `E13.Common` library to enhance type safety and flexibility. The changes primarily affect the audit context, entity interfaces, and database interceptors, requiring updates to dependent tests and sample implementations.

### Core Refactoring to Add Generic Type Parameter `T`:

* **Audit Context and BaseDbContext**:
  - `IAuditContext` now accepts a generic type parameter `T` for `AuditUser` to support non-string user identifiers. (`src/E13.Common.Data.Db/IAuditContext.cs`, [src/E13.Common.Data.Db/IAuditContext.csL9-R11](diffhunk://#diff-d6ae050e5ddcf0762add6f34116fbcbdbfd836e7c54f32b3e132eb8517345899L9-R11))
  - `BaseDbContext` is updated to `BaseDbContext<T>` to align with the new `IAuditContext<T>` interface. (`src/E13.Common.Data.Db/BaseDbContext.cs`, [[1]](diffhunk://#diff-dfced73ee6db71ce719cba58553a928b5ec4ec7edd61be9f4388309633b4186cL19-R19) [[2]](diffhunk://#diff-dfced73ee6db71ce719cba58553a928b5ec4ec7edd61be9f4388309633b4186cL28-R28)

* **Entity Interfaces**:
  - Interfaces like `ICreatable`, `IDeletable`, `IModifiable`, and others now accept a generic type parameter `T` for user-related fields (e.g., `CreatedBy`, `DeletedBy`). (`src/E13.Common.Domain/ICreatable.cs`, [[1]](diffhunk://#diff-05f6acf7507a5c7f7bd8a1f57c2ba0fed5e6c150807f7249585cad610d193382L9-R11); `src/E13.Common.Domain/IDeletable.cs`, [[2]](diffhunk://#diff-2bcb531e2dc38851208ba801f18d9c67ae94b61dd8874d14c3ea07b11699c782L7-R9)

### Interceptor Updates:

* **Database Interceptors**:
  - `CreatableInterceptor`, `ModifiableInterceptor`, and `SoftDeleteInterceptor` are updated to use `IAuditContext<T>` and the generic entity interfaces (e.g., `ICreatable<T>`). (`src/E13.Common.Data.Db/Interceptors/CreatableInterceptor.cs`, [[1]](diffhunk://#diff-67e9158878e970329ab9b76ea0b84acac8c1954dcc63cb5065d768e80f8c8a02L13-R19); `src/E13.Common.Data.Db/Interceptors/ModifiableInterceptor.cs`, [[2]](diffhunk://#diff-9ad0c78a5e07762cc57a1e834a5d7079ed968dd51397dd933777ccb5b44aa524L14-R20)

### Test Updates:

* **Test Contexts and Assertions**:
  - Updated test classes and methods to use `BaseDbContext<string>` and generic interceptors. (`test/E13.Common.Data.Db.Tests/BaseDbContext_ICreatableTests.cs`, [test/E13.Common.Data.Db.Tests/BaseDbContext_ICreatableTests.csL20-R30](diffhunk://#diff-90da8e3d4efe4e21b984090efe006b9b5fe5f6816c61e2f913dbbef061a5d468L20-R30))
  - Adjusted assertions to reference `BaseDbContext<string>.UnknownUser` for compatibility with the new generic implementation. (`test/E13.Common.Data.Db.Tests/BaseDbContext_ICreatableTests.cs`, [test/E13.Common.Data.Db.Tests/BaseDbContext_ICreatableTests.csL59-R59](diffhunk://#diff-90da8e3d4efe4e21b984090efe006b9b5fe5f6816c61e2f913dbbef061a5d468L59-R59))

### Sample Code Adjustments:

* **Sample Entities and Context**:
  - Updated sample implementations, such as `TestCreatable` and `TestDbContext`, to use the generic interfaces and `BaseDbContext<T>`. (`test/E13.Common.Data.Db.Tests/Sample/TestCreatable.cs`, [[1]](diffhunk://#diff-bc0e71633045269817d1347d59c5b0dd048b1a0cd98c6e54d47ac41a74f41e48L10-R10); `test/E13.Common.Data.Db.Tests/Sample/TestDbContext.cs`, [[2]](diffhunk://#diff-12a35ebc2acac5ced107ba721c8bb3f510e25088aaef4557b7e93317e3b8e185L11-R11)