### PR TITLE
workflow updates for manual execution

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,6 +1,7 @@
 name: CD
 
 on:
+  workflow_dispatch: 
   push:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch: 
   pull_request:
     branches:
       - main


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to include manual triggers via `workflow_dispatch`. These changes allow developers to manually trigger the workflows for both CI and CD pipelines.

Updates to GitHub Actions workflows:

* [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R4): Added `workflow_dispatch` to enable manual triggering of the CD workflow.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR4): Added `workflow_dispatch` to enable manual triggering of the CI workflow.