### PR TITLE
Nullable Reference types

### DIFF
--- a/src/E13.Common.Domain/IDeletable.cs
+++ b/src/E13.Common.Domain/IDeletable.cs
@@ -6,7 +6,7 @@ namespace E13.Common.Domain
 {
     public interface IDeletable<T> : IEntity
     {
-        T DeletedBy { get; set; }
+        T? DeletedBy { get; set; }
         string? DeletedSource { get; set; }
         DateTime? Deleted { get; set; }
 

--- a/src/E13.Common.Domain/IEffectable.cs
+++ b/src/E13.Common.Domain/IEffectable.cs
@@ -6,7 +6,7 @@ namespace E13.Common.Domain
 {
     public interface IEffectable<T> : IEntity
     {
-        T EffectiveBy { get; set; }
+        T? EffectiveBy { get; set; }
         string? EffectiveSource { get; set; }
         DateTime? Effective { get; set; }
     }

--- a/src/E13.Common.Domain/IExpirable.cs
+++ b/src/E13.Common.Domain/IExpirable.cs
@@ -6,7 +6,7 @@ namespace E13.Common.Domain
 {
     public interface IExpirable<T> : IEntity
     {
-        T ExpirationBy { get; set; }
+        T? ExpirationBy { get; set; }
         string? ExpirationSource { get; set; }
         DateTime? Expiration { get; set; }
     }

--- a/src/E13.Common.Domain/IModifiable.cs
+++ b/src/E13.Common.Domain/IModifiable.cs
@@ -8,7 +8,7 @@ namespace E13.Common.Domain
 {
     public interface IModifiable<T> : IEntity
     {
-        T ModifiedBy { get; set; }
+        T? ModifiedBy { get; set; }
         string? ModifiedSource { get; set; }
         DateTime? Modified { get; set; }
     }

--- a/src/E13.Common.Domain/IOwnable.cs
+++ b/src/E13.Common.Domain/IOwnable.cs
@@ -6,7 +6,7 @@ namespace E13.Common.Domain
 {
     public interface IOwnable<T> : IEntity
     {
-        T OwnedBy { get; set; }
+        T? OwnedBy { get; set; }
         string? OwnedSource { get; set; }
         DateTime? Owned { get; set; }
     }


### PR DESCRIPTION
This pull request introduces nullable reference types for several properties in domain interfaces to enhance compatibility with scenarios where the properties might not always have a value. The changes primarily focus on making the `T` type properties nullable in five interfaces.

### Nullable reference type adjustments:

* [`src/E13.Common.Domain/IDeletable.cs`](diffhunk://#diff-2bcb531e2dc38851208ba801f18d9c67ae94b61dd8874d14c3ea07b11699c782L9-R9): Updated the `DeletedBy` property to be nullable (`T?`) to allow for cases where no deletion user is specified.
* [`src/E13.Common.Domain/IEffectable.cs`](diffhunk://#diff-588208ba9f8bdbea2ad149d800134a66315f1a706eafc054af2e998b07558c67L9-R9): Updated the `EffectiveBy` property to be nullable (`T?`) to accommodate scenarios where no effective user is provided.
* [`src/E13.Common.Domain/IExpirable.cs`](diffhunk://#diff-f86230c924b9e2e1a55df3dd5e8d42f990c5452566a12576edcdddd1b038dc01L9-R9): Updated the `ExpirationBy` property to be nullable (`T?`) to handle situations where no expiration user is defined.
* [`src/E13.Common.Domain/IModifiable.cs`](diffhunk://#diff-1ee5e5d92bac41b8a9fefdd9bc111115c1f8cbf65293a7075b2ba743b0f7baedL11-R11): Updated the `ModifiedBy` property to be nullable (`T?`) to support cases where no modification user is specified.
* [`src/E13.Common.Domain/IOwnable.cs`](diffhunk://#diff-1fd14297cdaef9403383297277086f4ee3f4864682463c8ed9988b9e8fcd240fL9-R9): Updated the `OwnedBy` property to be nullable (`T?`) to allow for ownership to be unspecified.